### PR TITLE
Fix float type cast in StructuredModel.py

### DIFF
--- a/nion/utils/StructuredModel.py
+++ b/nion/utils/StructuredModel.py
@@ -62,10 +62,10 @@ def define_array(items: MDescription) -> MDescription:
 
 
 def build_model(schema: MDescription, *, default_value=None, value=None):
-    if schema in ("string", "boolean", "int", "float"):
+    if schema in ("string", "boolean", "int", "double"):
         return FieldPropertyModel(default_value if default_value is not None else value)
     type = typing.cast(dict, schema).get("type")
-    if type in ("string", "boolean", "int", "float"):
+    if type in ("string", "boolean", "int", "double"):
         return FieldPropertyModel(default_value if default_value is not None else value)
     elif type == "record":
         record_values = copy.copy(default_value or dict())
@@ -76,10 +76,10 @@ def build_model(schema: MDescription, *, default_value=None, value=None):
 
 
 def build_value(schema: MDescription, *, value=None):
-    if schema in ("string", "boolean", "int", "float"):
+    if schema in ("string", "boolean", "int", "double"):
         return value
     type = typing.cast(dict, schema).get("type")
-    if type in ("string", "boolean", "int", "float"):
+    if type in ("string", "boolean", "int", "double"):
         return value
     elif type == "record":
         return RecordModel(schema, values=value)


### PR DESCRIPTION
Dear Nion devs,

I believe there's a bug in `nion/utils/StructuredModel.py` where the type cast of the `StructuredModel.FLOAT` is not correctly defined. I have tried to fix this in this PR with minimal changes. Anyway, I am really not familiar with the code, and I can only hope I haven't broken anything. 

Best,
Alberto.

# Description of the changes

- The `StructuredModel` class defines variables 'INT', 'FLOAT' ...
- The 'StructuredModel.FLOAT' variable points to the string `'double'`.
- Typing casts are defined for the strings, however no typing cast is defined for the `'double'` string.
- However, typing cast is defined for the `'float'` string, which is weird.
- I have tried to fix this.