### PR TITLE
no close

### DIFF
--- a/nion/utils/Binding.py
+++ b/nion/utils/Binding.py
@@ -62,16 +62,7 @@ class Binding:
 
     # not thread safe
     def close(self) -> None:
-        """Close the binding.
-
-        Closes the binding. Subclasses can use this to perform any shutdown
-        related actions. Not thread safe.
-        """
-        self.__source_ref = None
-        self.source_getter = None
-        self.source_setter = None
-        self.target_setter = None
-        self._closed = True
+        pass
 
     @property
     def source(self) -> typing.Optional[typing.Any]:
@@ -222,11 +213,6 @@ class PropertyBinding(Binding):
         self.source_setter = weak_partial(set_property_value, self.source)
         self.source_getter = weak_partial(get_property_value, self.source)
 
-    def close(self) -> None:
-        self.__property_changed_listener.close()
-        self.__property_changed_listener = typing.cast(typing.Any, None)
-        super().close()
-
     @property
     def property_name(self) -> str:
         return self.__property_name
@@ -286,11 +272,6 @@ class PropertyAttributeBinding(Binding):
         self.source_setter = weak_partial(source_setter, self.source)
         self.source_getter = weak_partial(source_getter, self.source)
 
-    def close(self) -> None:
-        self.__property_changed_listener.close()
-        self.__property_changed_listener = typing.cast(typing.Any, None)
-        super().close()
-
 
 class TuplePropertyBinding(Binding):
     """Two way binding from an element within a source property tuple to a target.
@@ -342,8 +323,3 @@ class TuplePropertyBinding(Binding):
 
         self.source_setter = weak_partial(source_setter, self.source)
         self.source_getter = weak_partial(source_getter, self.source)
-
-    def close(self) -> None:
-        self.__property_changed_listener.close()
-        self.__property_changed_listener = typing.cast(typing.Any, None)
-        super().close()

--- a/nion/utils/Event.py
+++ b/nion/utils/Event.py
@@ -87,8 +87,6 @@ class Event:
             self.__weak_listeners.append(weak_listener)
         if owner:
             def owner_gone(weak_owner: typing.Any) -> None:
-                listener = self.__listeners[id(weak_owner)][0]
-                listener.close()
                 del self.__listeners[id(weak_owner)]
 
             weak_owner = weakref.ref(owner, owner_gone)

--- a/nion/utils/ListModel.py
+++ b/nion/utils/ListModel.py
@@ -301,35 +301,7 @@ class FilteredListModel(Observable.Observable):
         self.container = container
 
     def close(self) -> None:
-        if self.__container:
-            if self.__item_inserted_event_listener:
-                self.__item_inserted_event_listener.close()
-                self.__item_inserted_event_listener = None
-            if self.__item_removed_event_listener:
-                self.__item_removed_event_listener.close()
-                self.__item_removed_event_listener = None
-            if self.__begin_changes_event_listener:
-                self.__begin_changes_event_listener.close()
-                self.__begin_changes_event_listener = None
-            if self.__end_changes_event_listener:
-                self.__end_changes_event_listener.close()
-                self.__end_changes_event_listener = None
-            if self.__reset_list_event_listener:
-                self.__reset_list_event_listener.close()
-                self.__reset_list_event_listener = None
-            for item in reversed(copy.copy(self._get_master_items())):
-                index = len(self._get_master_items()) - 1
-                del self.__master_items[index]
-                if self.__item_changed_event_listeners[index]:
-                    self.__item_changed_event_listeners[index].close()
-                del self.__item_changed_event_listeners[index]
-                if item in self.__items:
-                    item_index = self.__items.index(item)
-                    del self.__items[item_index]
-        self.__container = None
-        self.__item_changed_event_listeners = list()
-        self.__master_items = list()
-        self.__items = list()
+        pass
 
     def begin_change(self) -> None:
         """ Begin a set of changes. Balance with end_changes. """
@@ -751,9 +723,7 @@ class MappedListModel(Observable.Observable):
         self.container = container
 
     def close(self) -> None:
-        self.container = None
-        self.__map_fn = typing.cast(MappedListModel._MapFunctionType, None)
-        self.__unmap_fn = typing.cast(MappedListModel._MapFunctionType, None)
+        pass
 
     def begin_change(self) -> None:
         """ Begin a set of changes. Balance with end_changes. """
@@ -908,7 +878,7 @@ class FlattenedListModel(Observable.Observable):
         self.container = container
 
     def close(self) -> None:
-        self.container = None
+        pass
 
     @property
     def items(self) -> typing.Sequence[typing.Any]:
@@ -1029,9 +999,7 @@ class ListPropertyModel(Observable.Observable):
         self.__item_removed_event_listener = list_model.item_removed_event.listen(weak_partial(ListPropertyModel.__item_removed, self))
 
     def close(self) -> None:
-        self.__list_model = typing.cast(ListModelLike, None)
-        self.__item_inserted_event_listener = typing.cast(Event.EventListener, None)
-        self.__item_removed_event_listener = typing.cast(Event.EventListener, None)
+        pass
 
     def __item_inserted(self, key: str, item: typing.Any, before_index: int) -> None:
         self.notify_property_changed("value")

--- a/nion/utils/ListModel.py
+++ b/nion/utils/ListModel.py
@@ -601,21 +601,11 @@ class FilteredListModel(Observable.Observable):
     @container.setter
     def container(self, container: typing.Optional[Observable.Observable]) -> None:
         if self.__container:
-            assert self.__item_inserted_event_listener
-            self.__item_inserted_event_listener.close()
             self.__item_inserted_event_listener = None
-            assert self.__item_removed_event_listener
-            self.__item_removed_event_listener.close()
             self.__item_removed_event_listener = None
-            if self.__begin_changes_event_listener:
-                self.__begin_changes_event_listener.close()
-                self.__begin_changes_event_listener = None
-            if self.__end_changes_event_listener:
-                self.__end_changes_event_listener.close()
-                self.__end_changes_event_listener = None
-            if self.__reset_list_event_listener:
-                self.__reset_list_event_listener.close()
-                self.__reset_list_event_listener = None
+            self.__begin_changes_event_listener = None
+            self.__end_changes_event_listener = None
+            self.__reset_list_event_listener = None
             for item in reversed(copy.copy(self._get_master_items())):
                 self.__item_removed(self.__master_items_key, item, len(self._get_master_items()) - 1)
         self.__container = container
@@ -688,8 +678,6 @@ class FilteredListModel(Observable.Observable):
         if key == self.__master_items_key:
             with self._update_mutex:
                 del self.__master_items[index]
-                if self.__item_changed_event_listeners[index]:
-                    self.__item_changed_event_listeners[index].close()
                 del self.__item_changed_event_listeners[index]
                 self.__removed_master_item(index, item)
 
@@ -783,18 +771,10 @@ class MappedListModel(Observable.Observable):
     def container(self, container: typing.Optional[Observable.Observable]) -> None:
         # remove old master items
         if self.__container:
-            assert self.__item_inserted_event_listener
-            self.__item_inserted_event_listener.close()
             self.__item_inserted_event_listener = None
-            assert self.__item_removed_event_listener
-            self.__item_removed_event_listener.close()
             self.__item_removed_event_listener = None
-            if self.__begin_changes_event_listener:
-                self.__begin_changes_event_listener.close()
-                self.__begin_changes_event_listener = None
-            if self.__end_changes_event_listener:
-                self.__end_changes_event_listener.close()
-                self.__end_changes_event_listener = None
+            self.__begin_changes_event_listener = None
+            self.__end_changes_event_listener = None
             for item in reversed(copy.copy(getattr(self.__container, self.__master_items_key))):
                 self.__master_item_removed(self.__master_items_key, item, len(self.__items) - 1)
         # add new master items
@@ -901,11 +881,7 @@ class FlattenedListModel(Observable.Observable):
     def container(self, container: typing.Optional[Observable.Observable]) -> None:
         # remove old master items
         if self.__container:
-            assert self.__item_inserted_event_listener
-            self.__item_inserted_event_listener.close()
             self.__item_inserted_event_listener = None
-            assert self.__item_removed_event_listener
-            self.__item_removed_event_listener.close()
             self.__item_removed_event_listener = None
             for item in reversed(copy.copy(getattr(self.__container, self.__master_items_key))):
                 self.__master_item_removed(self.__master_items_key, item, len(self.__master_items) - 1)

--- a/nion/utils/Model.py
+++ b/nion/utils/Model.py
@@ -70,7 +70,7 @@ class FuncStreamValueModel(PropertyModel[T], typing.Generic[T]):
                  event_loop: asyncio.AbstractEventLoop, value: typing.Optional[T] = None,
                  cmp: typing.Optional[EqualityOperator] = None):
         super().__init__(value=value, cmp=cmp)
-        self.__value_func_stream = value_func_stream.add_ref()
+        self.__value_func_stream = value_func_stream
         self.__event_loop = event_loop
         self.__pending_task = Stream.StreamTask()
         self.__value_fn_ref: typing.List[typing.Callable[[], typing.Any]] = [lambda: None]
@@ -101,8 +101,8 @@ class FuncStreamValueModel(PropertyModel[T], typing.Generic[T]):
         self.__pending_task.create_task(update_value(self.__event, self.__evaluating, weakref.ref(self), self.__value_fn_ref))
         self.__stream_listener = value_func_stream.value_stream.listen(weak_partial(FuncStreamValueModel.__handle_value_func, self))
         value_func = self.__value_func_stream.value
-        assert value_func
-        self.__handle_value_func(value_func)
+        if value_func:
+            self.__handle_value_func(value_func)
 
         def finalize(pending_task: Stream.StreamTask) -> None:
             pending_task.clear()
@@ -132,7 +132,7 @@ class StreamValueModel(PropertyModel[T], typing.Generic[T]):
     def __init__(self, value_stream: Stream.AbstractStream[T], value: typing.Optional[T] = None,
                  cmp: typing.Optional[EqualityOperator] = None) -> None:
         super().__init__(value=value, cmp=cmp)
-        self.__value_stream = value_stream.add_ref()
+        self.__value_stream = value_stream
 
         def handle_value(model: StreamValueModel[T], value: typing.Any) -> None:
             model.value = value

--- a/nion/utils/Recorder.py
+++ b/nion/utils/Recorder.py
@@ -119,23 +119,7 @@ class Recorder:
                 self.__relationship_recorders[key].append(Recorder(item, IndexAccessor(KeyAccessor(self.__accessor, key), index), self.__logger))
 
     def close(self) -> None:
-        self.__property_changed_event_listener.close()
-        self.__property_changed_event_listener = None
-        self.__item_set_event_listener.close()
-        self.__item_set_event_listener = None
-        self.__item_cleared_event_listener.close()
-        self.__item_cleared_event_listener = None
-        self.__item_inserted_event_listener.close()
-        self.__item_inserted_event_listener = None
-        self.__item_removed_event_listener.close()
-        self.__item_removed_event_listener = None
-        for key, item_recorder in self.__item_recorders.items():
-            item_recorder.close()
-        self.__item_recorders = typing.cast(typing.Any, None)
-        for key, relationship_recorder_list in self.__relationship_recorders.items():
-            for relationship_recorder in self.__relationship_recorders[key]:
-                relationship_recorder.close()
-        self.__relationship_recorders = typing.cast(typing.Any, None)
+        pass
 
     def apply(self, object: Observable.Observable) -> None:
         self.__logger.apply(object)
@@ -156,9 +140,7 @@ class Recorder:
                 self._append_recorder_entry(KeyRecorderEntry(self.__accessor, key, getattr(object, key)))
 
     def __item_set(self, key: str, item: typing.Any) -> None:
-        item_recorder = self.__item_recorders.pop(key)
-        if item_recorder:
-            item_recorder.close()
+        self.__item_recorders.pop(key)
         if item:
             self.__item_recorders[key] = Recorder(item, KeyAccessor(self.__accessor, key), self.__logger)
         self._append_recorder_entry(KeyRecorderEntry(self.__accessor, key, copy.deepcopy(item)))
@@ -177,7 +159,7 @@ class Recorder:
         for index, relationship_recorder in enumerate(self.__relationship_recorders[key]):
             if index > item_index:
                 relationship_recorder._accessor = IndexAccessor(KeyAccessor(self.__accessor, key), index - 1)
-        self.__relationship_recorders[key].pop(item_index).close()
+        self.__relationship_recorders[key].pop(item_index)
         self._append_recorder_entry(RemoveRecorderEntry(self.__accessor, key, item_index))
 
     def _append_recorder_entry(self, recorder_entry: RecorderEntry) -> None:

--- a/nion/utils/StructuredModel.py
+++ b/nion/utils/StructuredModel.py
@@ -187,15 +187,7 @@ class RecordModel(Observable.Observable):
         self.__initialized = True
 
     def close(self) -> None:
-        for field_name in self.__field_models.keys():
-            self.__field_model_property_changed_listeners[field_name].close()
-            del self.__field_model_property_changed_listeners[field_name]
-            self.__array_item_inserted_listeners[field_name].close()
-            del self.__array_item_inserted_listeners[field_name]
-            self.__array_item_removed_listeners[field_name].close()
-            del self.__array_item_removed_listeners[field_name]
-            self.__field_model_changed_listeners[field_name].close()
-            del self.__field_model_changed_listeners[field_name]
+        pass
 
     def __deepcopy__(self, memo: typing.Dict[typing.Any, typing.Any]) -> RecordModel:
         values = self.to_dict_value()
@@ -299,14 +291,6 @@ class ArrayModel(ListModel.ListModel[typing.Any]):
                 trampoline = item.model_changed_event.listen(self.model_changed_event.fire)
             self.__model_changed_listeners.append(trampoline)
 
-    def close(self) -> None:
-        for index, item in enumerate(self.items):
-            trampoline = self.__model_changed_listeners[index]
-            if trampoline:
-                trampoline.close()
-        self.__model_changed_listeners = list()
-        super().close()
-
     def __deepcopy__(self, memo: typing.Dict[typing.Any, typing.Any]) -> ArrayModel:
         values = typing.cast(typing.Sequence[typing.Any], self.to_dict_value())
         # assert isinstance(values, list) or isinstance(values, tuple)
@@ -348,8 +332,6 @@ class ArrayModel(ListModel.ListModel[typing.Any]):
 
     def notify_remove_item(self, key: str, value: typing.Any, index: int) -> None:
         super().notify_remove_item(key, value, index)
-        trampoline = self.__model_changed_listeners.pop(index)
-        if trampoline:
-            trampoline.close()
+        self.__model_changed_listeners.pop(index)
         self.array_item_removed_event.fire(key, value, index)
         self.model_changed_event.fire()


### PR DESCRIPTION
- Eliminate need to close listeners, now automatic after unreferencing.
- Eliminate need to close streams. Automatic with unreferencing.
- Eliminate need to close models, list models.
- Make remaining close methods no-ops. Remove close calls.
