### PR TITLE
fix: preserve RGBA channel order in byte conversion

### DIFF
--- a/nion/utils/Color.py
+++ b/nion/utils/Color.py
@@ -75,14 +75,14 @@ class Color:
             rgb = tuple(int(hex_color[i:i + 1], 16) * 17 for i in (1, 2, 3))
             return rgb[0], rgb[1], rgb[2], 255
         elif hex_color and len(hex_color) == 5:
-            rgba = tuple(int(hex_color[i:i + 1], 16) * 17 for i in (1, 2, 3, 4))
-            return rgba[0], rgba[1], rgba[2], rgba[3]
+            argb = tuple(int(hex_color[i:i + 1], 16) * 17 for i in (1, 2, 3, 4))
+            return argb[1], argb[2], argb[3], argb[0]
         elif hex_color and len(hex_color) == 7:
             rgb = tuple(int(hex_color[i:i + 2], 16) for i in (1, 3, 5))
             return rgb[0], rgb[1], rgb[2], 255
         elif hex_color and len(hex_color) == 9:
-            rgba = tuple(int(hex_color[i:i + 2], 16) for i in (1, 3, 5, 7))
-            return rgba[0], rgba[1], rgba[2], rgba[3]
+            argb = tuple(int(hex_color[i:i + 2], 16) for i in (1, 3, 5, 7))
+            return argb[1], argb[2], argb[3], argb[0]
         else:
             return 255, 255, 255, 255
 

--- a/nion/utils/test/Color_test.py
+++ b/nion/utils/test/Color_test.py
@@ -65,3 +65,7 @@ class TestColorClass(unittest.TestCase):
     def test_color_hash(self) -> None:
         d = {Color.Color("thistle"): Color.Color("#d8bfd8")}
         self.assertEqual(d[Color.Color("thistle")], Color.Color("#d8bfd8"))
+
+    def test_rgba_255_uses_red_green_blue_alpha_order(self) -> None:
+        self.assertEqual((255, 0, 0, 127), Color.Color("rgba(255, 0, 0, 0.5)").to_rgba_255())
+        self.assertEqual((0x12, 0x34, 0x56, 0x80), Color.Color("#80123456").to_rgba_255())


### PR DESCRIPTION
## Summary

- return CSS RGBA colors from `to_rgba_255()` as `(red, green, blue, alpha)`
- apply the same ordering to short and long ARGB hex encodings
- add regression coverage for CSS RGBA and an alpha-prefixed hex color

Closes #21

## Validation

- `python3 -m unittest nion.utils.test.Color_test -v`
- `python3 -m unittest discover -s nion/utils/test -p "*_test.py"`
- `git diff --check`