### PR TITLE
fix: compare geometry safely to unrelated values

### DIFF
--- a/nion/utils/Geometry.py
+++ b/nion/utils/Geometry.py
@@ -367,6 +367,11 @@ class Margins:
     right: int
 
 
+def _is_compatible_geometry_type(value: typing.Any, geometry_type: typing.Type[typing.Any]) -> bool:
+    geometry_types = (IntPoint, IntSize, IntRect, FloatPoint, FloatSize, FloatRect)
+    return not isinstance(value, geometry_types) or isinstance(value, geometry_type)
+
+
 class IntPoint:
     """A class representing an integer point (x, y)."""
 
@@ -401,16 +406,16 @@ class IntPoint:
         return self.__y
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, IntPoint):
+            return False
+        try:
             other = IntPoint.make(other)
-            return bool((self.__x == other.x) and (self.__y == other.y))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__x == other.x) and (self.__y == other.y))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = IntPoint.make(other)
-            return bool((self.__x != other.x) or (self.__y != other.y))
-        return True
+        return not self == other
 
     def __neg__(self) -> IntPoint:
         return IntPoint(y=-self.__y, x=-self.__x)
@@ -517,16 +522,16 @@ class IntSize:
         return self.__height
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, IntSize):
+            return False
+        try:
             other = IntSize.make(other)
-            return bool((self.__width == other.width) and (self.__height == other.height))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__width == other.width) and (self.__height == other.height))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = IntSize.make(other)
-            return bool((self.__width != other.width) or (self.__height != other.height))
-        return True
+        return not self == other
 
     def __neg__(self) -> IntSize:
         return IntSize(-self.__height, -self.__width)
@@ -691,16 +696,16 @@ class IntRect:
         return slice(self.top, self.bottom), slice(self.left, self.right)
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, IntRect):
+            return False
+        try:
             other = IntRect.make(other)
-            return bool((self.__origin == other.origin) and (self.__size == other.size))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__origin == other.origin) and (self.__size == other.size))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = IntRect.make(other)
-            return bool((self.__origin != other.origin) or (self.__size != other.size))
-        return True
+        return not self == other
 
     @typing.overload
     def __getitem__(self, index: typing.Literal[0]) -> PointIntTuple: ...
@@ -818,16 +823,16 @@ class FloatPoint:
         return self.__y
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, FloatPoint):
+            return False
+        try:
             other = FloatPoint.make(other)
-            return bool((self.__x == other.x) and (self.__y == other.y))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__x == other.x) and (self.__y == other.y))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = FloatPoint.make(other)
-            return bool((self.__x != other.x) or (self.__y != other.y))
-        return True
+        return not self == other
 
     def __neg__(self) -> FloatPoint:
         return FloatPoint(y=-self.__y, x=-self.__x)
@@ -960,16 +965,16 @@ class FloatSize:
         return self.__height
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, FloatSize):
+            return False
+        try:
             other = FloatSize.make(other)
-            return bool((self.__width == other.width) and (self.__height == other.height))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__width == other.width) and (self.__height == other.height))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = FloatSize.make(other)
-            return bool((self.__width != other.width) or (self.__height != other.height))
-        return True
+        return not self == other
 
     def __neg__(self) -> FloatSize:
         return FloatSize(-self.__height, -self.__width)
@@ -1140,16 +1145,16 @@ class FloatRect:
         return FloatPoint(y=(self.top + self.bottom) / 2, x=(self.left + self.right) / 2)
 
     def __eq__(self, other: typing.Any) -> bool:
-        if other is not None:
+        if other is None or not _is_compatible_geometry_type(other, FloatRect):
+            return False
+        try:
             other = FloatRect.make(other)
-            return bool((self.__origin == other.origin) and (self.__size == other.size))
-        return False
+        except (TypeError, ValueError, IndexError):
+            return False
+        return bool((self.__origin == other.origin) and (self.__size == other.size))
 
     def __ne__(self, other: typing.Any) -> bool:
-        if other is not None:
-            other = FloatRect.make(other)
-            return bool((self.__origin != other.origin) or (self.__size != other.size))
-        return True
+        return not self == other
 
     @typing.overload
     def __getitem__(self, index: typing.Literal[0]) -> PointFloatTuple: ...

--- a/nion/utils/test/Geometry_test.py
+++ b/nion/utils/test/Geometry_test.py
@@ -39,6 +39,26 @@ class TestGeometryClass(unittest.TestCase):
         p2 = Geometry.IntPoint(x=0, y=2)
         self.assertNotEqual(p1, p2)
 
+    def test_geometry_values_compare_safely_to_unrelated_values(self) -> None:
+        geometry_values = (
+            Geometry.IntPoint(y=1, x=2),
+            Geometry.IntSize(height=1, width=2),
+            Geometry.IntRect.from_tlhw(1, 2, 3, 4),
+            Geometry.FloatPoint(y=1, x=2),
+            Geometry.FloatSize(height=1, width=2),
+            Geometry.FloatRect.from_tlhw(1, 2, 3, 4),
+        )
+
+        for value in geometry_values:
+            with self.subTest(value=value):
+                self.assertFalse(value == object())
+                self.assertTrue(value != object())
+                self.assertFalse(value == None)  # noqa: E711
+                self.assertTrue(value != None)  # noqa: E711
+
+        self.assertFalse(Geometry.IntPoint(y=1, x=2) == Geometry.IntSize(height=1, width=2))
+        self.assertFalse(Geometry.FloatPoint(y=1, x=2) == Geometry.FloatSize(height=1, width=2))
+
     def test_rect_intersects(self) -> None:
         r1 = Geometry.IntRect.from_tlbr(10,10,20,30)
         r2 = Geometry.IntRect.from_tlbr(0, 15, 30, 25)


### PR DESCRIPTION
## Summary

- return `False` / `True` instead of raising when geometry values are compared with unrelated objects
- prevent distinct geometry value types from comparing equal through tuple coercion
- cover each geometry value class with regression tests

Closes #3

## Validation

- `python3 -m unittest nion.utils.test.Geometry_test.TestGeometryClass.test_geometry_values_compare_safely_to_unrelated_values -v`
- `python3 -m unittest discover -s nion/utils/test -p "*_test.py"`
- `git diff --check`